### PR TITLE
Fix missing iam permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ For common use-cases, take a look at the [Examples][10] page.
 
 Below is a listing of plugin versions and respective Velero versions that are compatible.
 
-| Plugin Version | Velero Version |
-| -------------- | -------------- |
-| v1.1.x         | v1.4.x         |
-| v1.0.x         | v1.3.x         |
-| v1.0.x         | v1.2.0         |
+| Plugin Version  | Velero Version |
+|-----------------|----------------|
+| v1.1.x          | v1.4.x         |
+| v1.0.x          | v1.3.x         |
+| v1.0.x          | v1.2.0         |
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ For common use-cases, take a look at the [Examples][10] page.
 
 Below is a listing of plugin versions and respective Velero versions that are compatible.
 
-| Plugin Version  | Velero Version |
-|-----------------|----------------|
-| v1.1.x          | v1.4.x         |
-| v1.0.x          | v1.3.x         |
-| v1.0.x          | v1.2.0         |
+| Plugin Version | Velero Version |
+| -------------- | -------------- |
+| v1.1.x         | v1.4.x         |
+| v1.0.x         | v1.3.x         |
+| v1.0.x         | v1.2.0         |
 
 ## Setup
 
@@ -103,6 +103,7 @@ To integrate Velero with GCP, create a Velero-specific [Service Account][15]:
         compute.snapshots.useReadOnly
         compute.snapshots.delete
         compute.zones.get
+        storage.objects.list
     )
 
     gcloud iam roles create velero.server \


### PR DESCRIPTION
Before adding the `storage.objects.list` permission, I kept seeing in my log the following error: (below is a `stern` output from a `helm` deployment)

```
velero-64b9cb7bf7-w4vql velero time="2020-11-12T20:38:05Z" level=error msg="Error listing backups in backup store" backupLocation=velero-storage-backups controller=backup-sync error="rpc error: code = Unknown desc = googleapi: Error 403: my-service-account@my-project-id.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket., forbidden" error.file="/go/src/github.com/vmware-tanzu/velero-plugin-for-gcp/velero-plugin-for-gcp/object_store.go:191" error.function="main.(*ObjectStore).ListCommonPrefixes" logSource="pkg/controller/backup_sync_controller.go:175"
```