### PR TITLE
Added quotes to Workload Identity binding in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Next, add an IAM policy binding to grant Velero's Kubernetes service account acc
 ```bash
 gcloud iam service-accounts add-iam-policy-binding \
     --role roles/iam.workloadIdentityUser \
-    --member serviceAccount:[PROJECT_ID].svc.id.goog[velero/velero] \
+    --member "serviceAccount:[PROJECT_ID].svc.id.goog[velero/velero]" \
     [GSA_NAME]@[PROJECT_ID].iam.gserviceaccount.com
 ```
 


### PR DESCRIPTION
The service account for the binding requires quotes around it otherwise the command fails, see GCP documentation for reference. https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#using_from_your_code