### PR TITLE
Use credentials file passed through config

### DIFF
--- a/changelogs/unreleased/52-zubron
+++ b/changelogs/unreleased/52-zubron
@@ -1,0 +1,1 @@
+Add support for the new `credentialsFile` config key which enables per-BSL credentials. If set, the plugin will use this path as the credentials file for authentication rather than the credentials file path in the environment.

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"io"
+	"io/ioutil"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -34,9 +35,9 @@ import (
 )
 
 const (
-	credentialsEnvVar    = "GOOGLE_APPLICATION_CREDENTIALS"
-	kmsKeyNameConfigKey  = "kmsKeyName"
-	serviceAccountConfig = "serviceAccount"
+	kmsKeyNameConfigKey      = "kmsKeyName"
+	serviceAccountConfig     = "serviceAccount"
+	credentialsFileConfigKey = "credentialsFile"
 )
 
 // bucketWriter wraps the GCP SDK functions for accessing object store so they can be faked for testing.
@@ -76,12 +77,32 @@ func newObjectStore(logger logrus.FieldLogger) *ObjectStore {
 }
 
 func (o *ObjectStore) Init(config map[string]string) error {
-	if err := veleroplugin.ValidateObjectStoreConfigKeys(config, kmsKeyNameConfigKey, serviceAccountConfig); err != nil {
+	if err := veleroplugin.ValidateObjectStoreConfigKeys(config, kmsKeyNameConfigKey, serviceAccountConfig, credentialsFileConfigKey); err != nil {
 		return err
 	}
 	// Find default token source to extract the GoogleAccessID
 	ctx := context.Background()
-	creds, err := google.FindDefaultCredentials(ctx)
+
+	clientOptions := []option.ClientOption{
+		option.WithScopes(storage.ScopeReadWrite),
+	}
+
+	var creds *google.Credentials
+	var err error
+
+	// Prioritize the credentials file path in config, if it exists
+	if credentialsFile, ok := config[credentialsFileConfigKey]; ok {
+		b, err := ioutil.ReadFile(credentialsFile)
+		if err != nil {
+			return errors.Wrapf(err, "error reading provided credentials file %v", credentialsFile)
+		}
+		creds, err = google.CredentialsFromJSON(ctx, b)
+		clientOptions = append(clientOptions, option.WithCredentialsFile(credentialsFile))
+	} else {
+		// If a credentials file does not exist in the config, fall back to
+		// loading default credentials.
+		creds, err = google.FindDefaultCredentials(ctx)
+	}
 
 	if err != nil {
 		return errors.WithStack(err)
@@ -99,7 +120,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		return errors.WithStack(err)
 	}
 
-	client, err := storage.NewClient(ctx, option.WithScopes(storage.ScopeReadWrite))
+	client, err := storage.NewClient(ctx, clientOptions...)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -87,6 +87,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		option.WithScopes(storage.ScopeReadWrite),
 	}
 
+	// Credentials to use when creating signed URLs.
 	var creds *google.Credentials
 	var err error
 
@@ -96,11 +97,14 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		if err != nil {
 			return errors.Wrapf(err, "error reading provided credentials file %v", credentialsFile)
 		}
+
 		creds, err = google.CredentialsFromJSON(ctx, b)
+
+		// If using a credentials file, we also need to pass it when creating the client.
 		clientOptions = append(clientOptions, option.WithCredentialsFile(credentialsFile))
 	} else {
 		// If a credentials file does not exist in the config, fall back to
-		// loading default credentials.
+		// loading default credentials for signed URLs.
 		creds, err = google.FindDefaultCredentials(ctx)
 	}
 

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017, 2019 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add a new supported key to the config (`credentialsFile`) which allows
the path to a credentials file to be passed through to the ObjectStore
plugin. If that key is set in the config, use that file as the
credentials file for the GCP client.

Fixes vmware-tanzu/velero#3430

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>