### PR TITLE
storage object permissions for Velero server role

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ To integrate Velero with GCP, create a Velero-specific [Service Account][21]:
         compute.snapshots.useReadOnly
         compute.snapshots.delete
         compute.zones.get
+        storage.objects.create
+        storage.objects.delete
+        storage.objects.get
+        storage.objects.list
     )
 
     gcloud iam roles create velero.server \


### PR DESCRIPTION
storage object permissions are required in order for Velero to be able to list, get, update, and delete objects in the specified bucket

Signed-off-by: Salah Al Saleh <salahalsaleh1993@gmail.com>