### PR TITLE
[Fix] Migrate PV handler from in-tree to CSI Plugin, always hit PartiallyFailed issue

### DIFF
--- a/velero-plugin-for-gcp/volume_snapshotter.go
+++ b/velero-plugin-for-gcp/volume_snapshotter.go
@@ -284,8 +284,7 @@ func getSnapshotTags(veleroTags map[string]string, diskDescription string, log l
 	if diskDescription != "" {
 		if err := json.Unmarshal([]byte(diskDescription), &snapshotTags); err != nil {
 			// error decoding the disk's description, so just use the Velero-assigned tags
-			log.WithError(err).
-				Error("unable to decode disk's description as JSON, so only applying Velero-assigned tags to snapshot")
+			log.WithField("error", err.Error()).Warning("unable to decode disk's description as JSON, so only applying Velero-assigned tags to snapshot")
 			snapshotTags = veleroTags
 		} else {
 			// merge Velero-assigned tags with the disk's tags (note that we want current


### PR DESCRIPTION
## Reason:
We use the `iin-tree plugin` `kubernetes.io/gce-pd` before, recently we migrated these PVs to `out-tree`.
When the migration is complete, In our K8s Clusters, we found lots of `PartiallyFailed` for PV/PVC backups. 

## Root Cause:
if PV is generated by GCP CSI provisoner, the disk's description is fixed, and it is [a string](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/eeead671694490979f388c2cb86550418259a01f/pkg/gce-cloud-provider/compute/gce-compute.go#L327-L337).
Unfortunately, for velero gcp plugin, there have a logic that try to parse it as map. if failed, it will raise a [error message](https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/167679c7a4479acfce3512347cc077c39529aabd/velero-plugin-for-gcp/volume_snapshotter.go#L287-L289)
this error message will be captured and treat as [`PartiallyFailed`](https://github.com/vmware-tanzu/velero/blob/02013ef3354f23041aa7a7689072889fa6491c74/pkg/controller/backup_controller.go#L646)

## Solution:
Lower the error level