### PR TITLE
support for multi arch images

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.17
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
         go-version: 1.17
@@ -21,6 +21,18 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
 
     - name: Build
       run: make local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017, 2019 the Velero contributors.
+# Copyright the Velero contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17-buster AS build
+FROM --platform=$BUILDPLATFORM golang:1.17-buster AS build
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ENV GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOARM=${TARGETVARIANT}
+
 COPY . /go/src/velero-plugin-for-gcp
 WORKDIR /go/src/velero-plugin-for-gcp
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o /go/bin/velero-plugin-for-gcp ./velero-plugin-for-gcp
+RUN export GOARM=$( echo "${GOARM}" | cut -c2-) && \
+    CGO_ENABLED=0 go build -v -o /go/bin/velero-plugin-for-gcp ./velero-plugin-for-gcp
 
 FROM busybox:1.34.1 AS busybox
 

--- a/Makefile
+++ b/Makefile
@@ -12,29 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The binary to build (just the basename).
+BIN ?= velero-plugin-for-gcp
+
+# This repo's root import path (under GOPATH).
 PKG := github.com/vmware-tanzu/velero-plugin-for-gcp
-BIN := velero-plugin-for-gcp
 
-REGISTRY 	?= velero
-IMAGE 		?= $(REGISTRY)/velero-plugin-for-gcp
-VERSION 	?= main
+# Where to push the docker image.
+REGISTRY ?= velero
 
-# Which architecture to build.
-# if the 'local' rule is being run, detect the GOOS/GOARCH from 'go env'
+# Image name
+IMAGE ?= $(REGISTRY)/$(BIN)
+
+# We allow the Dockerfile to be configurable to enable the use of custom Dockerfiles
+# that pull base images from different registries.
+VELERO_DOCKERFILE ?= Dockerfile
+
+# Which architecture to build - see $(ALL_ARCH) for options.
+# if the 'local' rule is being run, detect the ARCH from 'go env'
 # if it wasn't specified by the caller.
-local: GOOS ?= $(shell go env GOOS)
-GOOS ?= linux
+local : ARCH ?= $(shell go env GOOS)-$(shell go env GOARCH)
+ARCH ?= linux-amd64
 
-local: GOARCH ?= $(shell go env GOARCH)
-GOARCH ?= amd64
+VERSION ?= main
 
-# local builds the binary using 'go build' in the local environment.
+TAG_LATEST ?= false
+
+ifeq ($(TAG_LATEST), true)
+	IMAGE_TAGS ?= $(IMAGE):$(VERSION) $(IMAGE):latest
+else
+	IMAGE_TAGS ?= $(IMAGE):$(VERSION)
+endif
+
+ifeq ($(shell docker buildx inspect 2>/dev/null | awk '/Status/ { print $$2 }'), running)
+	BUILDX_ENABLED ?= true
+else
+	BUILDX_ENABLED ?= false
+endif
+
+define BUILDX_ERROR
+buildx not enabled, refusing to run this recipe
+see: https://velero.io/docs/main/build-from-source/#making-images-and-updating-velero for more info
+endef
+
+CLI_PLATFORMS ?= linux-amd64 linux-arm linux-arm64 darwin-amd64 darwin-arm64 windows-amd64 linux-ppc64le
+BUILDX_PLATFORMS ?= $(subst -,/,$(ARCH))
+BUILDX_OUTPUT_TYPE ?= docker
+
+# set git sha and tree state
+GIT_SHA = $(shell git rev-parse HEAD)
+ifneq ($(shell git status --porcelain 2> /dev/null),)
+	GIT_TREE_STATE ?= dirty
+else
+	GIT_TREE_STATE ?= clean
+endif
+
+###
+### These variables should not need tweaking.
+###
+
+platform_temp = $(subst -, ,$(ARCH))
+GOOS = $(word 1, $(platform_temp))
+GOARCH = $(word 2, $(platform_temp))
+GOPROXY ?= https://proxy.golang.org
+
 local: build-dirs
 	GOOS=$(GOOS) \
 	GOARCH=$(GOARCH) \
+	VERSION=$(VERSION) \
+	REGISTRY=$(REGISTRY) \
 	PKG=$(PKG) \
 	BIN=$(BIN) \
-	OUTPUT_DIR=$$(pwd)/_output \
+	GIT_SHA=$(GIT_SHA) \
+	GIT_TREE_STATE=$(GIT_TREE_STATE) \
+	OUTPUT_DIR=$$(pwd)/_output/bin/$(GOOS)/$(GOARCH) \
 	./hack/build.sh
 
 # test runs unit tests using 'go test' in the local environment.
@@ -44,23 +95,25 @@ test:
 # ci is a convenience target for CI builds.
 ci: verify-modules test
 
-# container builds a Docker image containing the binary.
-.PHONY: container
 container:
-	docker build -t $(IMAGE):$(VERSION) .
-
-# push pushes the Docker image to its registry.
-.PHONY: push
-push: container
-	@docker push $(IMAGE):$(VERSION)
-ifeq ($(TAG_LATEST), true)
-	docker tag $(IMAGE):$(VERSION) $(IMAGE):latest
-	docker push $(IMAGE):latest
+ifneq ($(BUILDX_ENABLED), true)
+	$(error $(BUILDX_ERROR))
 endif
+	@docker buildx build --pull \
+	--output=type=$(BUILDX_OUTPUT_TYPE) \
+	--platform $(BUILDX_PLATFORMS) \
+	$(addprefix -t , $(IMAGE_TAGS)) \
+	--build-arg=PKG=$(PKG) \
+	--build-arg=BIN=$(BIN) \
+	--build-arg=VERSION=$(VERSION) \
+	--build-arg=GIT_SHA=$(GIT_SHA) \
+	--build-arg=GIT_TREE_STATE=$(GIT_TREE_STATE) \
+	--build-arg=REGISTRY=$(REGISTRY) \
+	-f $(VELERO_DOCKERFILE) .
+	@echo "container: $(IMAGE):$(VERSION)"
 
-# build-dirs creates the necessary directories for a build in the local environment.
 build-dirs:
-	@mkdir -p _output
+	@mkdir -p _output/bin/$(GOOS)/$(GOARCH)
 
 .PHONY: modules
 modules:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017, 2019 the Velero contributors.
+# Copyright the Velero contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -78,12 +78,24 @@ elif [[ "$TAG" == "$HIGHEST" ]]; then
     TAG_LATEST=true
 fi
 
+if [[ -z "$BUILDX_PLATFORMS" ]]; then
+    BUILDX_PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
+fi
+
 # Debugging info
 echo "Highest tag found: $HIGHEST"
 echo "BRANCH: $BRANCH"
 echo "TAG: $TAG"
 echo "TAG_LATEST: $TAG_LATEST"
+echo "BUILDX_PLATFORMS: $BUILDX_PLATFORMS"
 
 echo "Building and pushing container images."
 
-VERSION="$VERSION" TAG_LATEST="$TAG_LATEST" make container push
+# The use of "registry" as the buildx output type below instructs
+# Docker to push the image
+
+VERSION="$VERSION" \
+TAG_LATEST="$TAG_LATEST" \
+BUILDX_PLATFORMS="$BUILDX_PLATFORMS" \
+BUILDX_OUTPUT_TYPE="registry" \
+make container

--- a/hack/docker-push.sh
+++ b/hack/docker-push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019 the Velero contributors.
+# Copyright the Velero contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR does implement building multi arch images and is a fix for https://github.com/vmware-tanzu/velero/issues/3569

It is based on the implementation used in https://github.com/vmware-tanzu/velero

It does use docker buildx to create multi arch images.
These changes might also be adopted for velero-plugin-for-aws, to improve the multi arch build process.

I did a successful run in my fork here https://github.com/vchrisb/velero-plugin-for-gcp/actions/runs/1817369440, which did push the image here: https://hub.docker.com/repository/docker/vchrisb/velero-plugin-for-gcp