### PR TITLE
Bump up golang to 1.17.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.6-buster AS build
+FROM golang:1.17.8-buster AS build
 COPY . /go/src/velero-plugin-for-gcp
 WORKDIR /go/src/velero-plugin-for-gcp
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o /go/bin/velero-plugin-for-gcp ./velero-plugin-for-gcp


### PR DESCRIPTION
Bump up golang to 1.17.8

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>