### PR TITLE
Bump the Golang version to v1.19 for main

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.18-bullseye AS build
+FROM --platform=$BUILDPLATFORM golang:1.19-bullseye AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/changelogs/unreleased/129-blackpiglet
+++ b/changelogs/unreleased/129-blackpiglet
@@ -1,0 +1,1 @@
+Bump up Golang version to v1.19 for main.


### PR DESCRIPTION
Bump the Golang version to v1.19 for the GCP plugin's main branch.