### PR TITLE
Unbreaking cross-project restores.

### DIFF
--- a/velero-plugin-for-gcp/volume_snapshotter.go
+++ b/velero-plugin-for-gcp/volume_snapshotter.go
@@ -98,10 +98,13 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 
 	b.snapshotLocation = config[snapshotLocationKey]
 
+	b.volumeProject = creds.ProjectID
+    /*
 	b.volumeProject = config[projectKey]
 	if b.volumeProject == "" {
 		b.volumeProject = creds.ProjectID
 	}
+    */
 
 	// get snapshot project from 'project' config key if specified,
 	// otherwise from the credentials file


### PR DESCRIPTION
According to this [comment](https://github.com/vmware-tanzu/velero/issues/6038#issue-1642030113), we just have to revert this [change](https://github.com/vmware-tanzu/velero-plugin-for-gcp/pull/92). It's worth a try. It's not the fix they are looking for, but it will make our lives easier for this one case.