### PR TITLE
[main]Replace busybox with internal copy binary and fix CVEs.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: '1.20'
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19
+        go-version: '1.20'
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.19-bullseye AS build
+FROM --platform=$BUILDPLATFORM golang:1.20-bullseye AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -27,12 +27,11 @@ ENV GOOS=${TARGETOS} \
 COPY . /go/src/velero-plugin-for-gcp
 WORKDIR /go/src/velero-plugin-for-gcp
 RUN export GOARM=$( echo "${GOARM}" | cut -c2-) && \
-    CGO_ENABLED=0 go build -v -o /go/bin/velero-plugin-for-gcp ./velero-plugin-for-gcp
-
-FROM busybox:1.36.0-uclibc AS busybox
+    CGO_ENABLED=0 go build -v -o /go/bin/velero-plugin-for-gcp ./velero-plugin-for-gcp && \
+    CGO_ENABLED=0 go build -v -o /go/bin/cp-plugin ./hack/cp-plugin
 
 FROM scratch
 COPY --from=build /go/bin/velero-plugin-for-gcp /plugins/
-COPY --from=busybox /bin/cp /bin/cp
+COPY --from=build /go/bin/cp-plugin /bin/cp-plugin
 USER 65532:65532
-ENTRYPOINT ["cp", "/plugins/velero-plugin-for-gcp", "/target/."]
+ENTRYPOINT ["cp-plugin", "/plugins/velero-plugin-for-gcp", "/target/velero-plugin-for-gcp"]

--- a/changelogs/unreleased/137-blackpiglet
+++ b/changelogs/unreleased/137-blackpiglet
@@ -1,0 +1,1 @@
+Replace busybox with internal copy binary and fix CVEs.

--- a/hack/cp-plugin/main.go
+++ b/hack/cp-plugin/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Println(
+			`Error: This command requires two arguments.
+Usage: cp-plugin src dst`)
+		os.Exit(1)
+	}
+	src, dst := os.Args[1], os.Args[2]
+	fmt.Printf("Copying %s to %s ...  ", src, dst)
+	srcFile, err := os.Open(src)
+	if err != nil {
+		panic(err)
+	}
+	defer srcFile.Close()
+	if _, err := os.Stat(dst); errors.Is(err, os.ErrNotExist) {
+		_, err = os.Create(dst)
+		if err != nil {
+			panic(err)
+		}
+	}
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY, 0755)
+	if err != nil {
+		panic(err)
+	}
+	defer dstFile.Close()
+	buf := make([]byte, 1024*128)
+	_, err = io.CopyBuffer(dstFile, srcFile, buf)
+	if err != nil {
+		panic(err)
+	}
+	os.Chmod(dst, 0755)
+	fmt.Println("done.")
+}


### PR DESCRIPTION
Replace the busybox image.
Bump Golang version to v1.20.

Due to actions/setup-python's limitation, golang's version 1.20 is parsed into 1.2. Need to use '1.20' instead.
https://github.com/actions/setup-go/issues/326#issuecomment-1415719692