### PR TITLE
feat: Add cross-project backup and restore support

### DIFF
--- a/changelogs/unreleased/143-Savostov-Arseny
+++ b/changelogs/unreleased/143-Savostov-Arseny
@@ -1,0 +1,5 @@
+Add cross-project backup and restore functionality in the Velero GCP Plugin.
+
+The main changes include:
+Replaced compute.Disks.CreateSnapshot with compute.Snapshots.insert to enable cross-project snapshots.
+Configured the volumeProject to use the project from the provided GCP credentials and snapshotProject to use the project from the plugin configuration.

--- a/velero-plugin-for-gcp/volume_snapshotter.go
+++ b/velero-plugin-for-gcp/volume_snapshotter.go
@@ -98,10 +98,7 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 
 	b.snapshotLocation = config[snapshotLocationKey]
 
-	b.volumeProject = config[projectKey]
-	if b.volumeProject == "" {
-		b.volumeProject = creds.ProjectID
-	}
+	b.volumeProject = creds.ProjectID
 
 	// get snapshot project from 'project' config key if specified,
 	// otherwise from the credentials file
@@ -275,13 +272,14 @@ func (b *VolumeSnapshotter) createSnapshot(snapshotName, volumeID, volumeAZ stri
 	gceSnap := compute.Snapshot{
 		Name:        snapshotName,
 		Description: getSnapshotTags(tags, disk.Description, b.log),
+		SourceDisk:  disk.SelfLink,
 	}
 
 	if b.snapshotLocation != "" {
 		gceSnap.StorageLocations = []string{b.snapshotLocation}
 	}
 
-	_, err = b.gce.Disks.CreateSnapshot(b.snapshotProject, volumeAZ, volumeID, &gceSnap).Do()
+	_, err = b.gce.Snapshots.Insert(b.snapshotProject, &gceSnap).Do()
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
@@ -298,13 +296,14 @@ func (b *VolumeSnapshotter) createRegionSnapshot(snapshotName, volumeID, volumeR
 	gceSnap := compute.Snapshot{
 		Name:        snapshotName,
 		Description: getSnapshotTags(tags, disk.Description, b.log),
+		SourceDisk:  disk.SelfLink,
 	}
 
 	if b.snapshotLocation != "" {
 		gceSnap.StorageLocations = []string{b.snapshotLocation}
 	}
 
-	_, err = b.gce.RegionDisks.CreateSnapshot(b.snapshotProject, volumeRegion, volumeID, &gceSnap).Do()
+	_, err = b.gce.Snapshots.Insert(b.snapshotProject, &gceSnap).Do()
 	if err != nil {
 		return "", errors.WithStack(err)
 	}


### PR DESCRIPTION
This commit introduces cross-project backup and restore functionality in the Velero GCP Plugin.

The main changes include:

- Replaced `compute.Disks.CreateSnapshot` with `compute.Snapshots.insert` to enable cross-project snapshots.
- Configured the `volumeProject` to use the project from the provided GCP credentials and `snapshotProject` to use the project from the plugin configuration.

Ref to github issue: https://github.com/vmware-tanzu/velero/issues/6441