### PR TITLE
Add Volume Project setting to support the scenario describe in issue #92

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,4 @@
 # Examples
 
-- [Restore snapshots from GCP across projects](./gcp-projects.md)
+- [Backup at project B, and restore at project A](./backup_at_b_restore_at_a.md)
+- [Velero at project A, backup and restore at other projects](./velero_at_a_br_at_other.md)

--- a/examples/backup_at_b_restore_at_a.md
+++ b/examples/backup_at_b_restore_at_a.md
@@ -1,4 +1,4 @@
-# Restore snapshots from GCP across projects
+# Backup at project B, and restore at project A
 
 These steps are heavily inspired by the [gcp documentation](https://cloud.google.com/compute/docs/images/sharing-images-across-projects).
 
@@ -26,7 +26,8 @@ The steps below assume that you have not setup Velero yet. So make sure to skip 
     - Assign [sa-b] "Storage Object Admin" permissions to [bucket-b]
   - Install velero on the k8s cluster in this project with configs
     - credentials: [sa-b]
-    - snapshotlocation: projectid=[project-b] and bucket=[bucket-b]
+    - snapshotlocation: projectid=[project-b]
+    - bucket: [bucket-b]
   - Create velero backup with the pvc snapshots desired [backup-b]
 
 - In [project-a]
@@ -34,7 +35,8 @@ The steps below assume that you have not setup Velero yet. So make sure to skip 
   - NOTE: Make sure to disable any scheduled backups.
   - Install velero on the k8s cluster in this project with configs
     - credentials: [sa-a]
-    - snapshotlocation: projectid=[project-b] and bucket=[bucket-b]
+    - snapshotlocation: projectid=[project-b]
+    - bucket: [bucket-b]
   - Create velero restore [restore-a] from [backup-b]
 
 If all was setup correctly, PVCs should be created from [project-b] snapshots.

--- a/examples/velero_at_a_br_at_other.md
+++ b/examples/velero_at_a_br_at_other.md
@@ -1,0 +1,51 @@
+# Velero at project A, backup and restore at other projects
+
+This scenario is introduced in [issue 4806](https://github.com/vmware-tanzu/velero/issues/4806).
+
+Assume the following...
+
+- Project A [project-a]: The project where the Velero's service account is located, and the Velero service account is granted to have enough permission to do backup and restore in the other projects.
+- Project B [project-b]: The GCP project we want to restore TO.
+- Project C [project-c]: The GCP project we want to restore FROM.
+
+## Set up Velero with permission in projects
+* In **project-a**
+  * Create "Velero Server" IAM role **role-a** with required role permissions.
+  * Create ServiceAccount **sa-a**.
+    * Assign **sa-a** with **role-a**.
+    * Assign **sa-a** with **role-b**(need to run after role-b created in project-b).
+    * Assign **sa-a** with **role-c**(need to run after role-c created in project-c).
+  * Create a bucket **bucket-a**.
+    * Assign [sa-a] "Storage Object Admin" permissions to [bucket-a]
+    * Assign [sa-b] "Storage Object Admin" permissions to [bucket-a](need to run after sa-b created in project-b)
+    * Assign [sa-c] "Storage Object Admin" permissions to [bucket-a](need to run after sa-c created in project-c)
+
+
+* In **project-b**
+  * Add the ServiceAccount **sa-a** into project **project-b** according to [Granting service accounts access to your projects](https://cloud.google.com/marketplace/docs/grant-service-account-access).
+  * Create ServiceAccount **sa-b**.
+  * Create "Velero Server" IAM role **role-b** with required role permissions.
+  * Assign **sa-b** with **role-b**.
+
+* In **project-c**
+  * Add the ServiceAccount **sa-a** into project **project-c** according to [Granting service accounts access to your projects](https://cloud.google.com/marketplace/docs/grant-service-account-access).
+  * Create ServiceAccount **sa-c**.
+  * Create "Velero Server" IAM role **role-c** with required role permissions.
+  * Assign **sa-c** with **role-c**.
+
+## Backup at project C
+* In **project-c**
+  * Install Velero on the k8s cluster in this project with configurations:
+    * SecretFile: **sa-a**
+    * SnapshotLocation: project=**project-a** and volumeProject=**project-c**
+    * Bucket: **bucket-a**
+  * Create Velero backup **backup-c** with the PVC snapshots desired.
+
+## Restore at project B
+* In **project-b**
+  * NOTE: Make sure to disable any scheduled backups.
+  * Install Velero on the k8s cluster in this project with configurations
+    * SecretFile: **sa-a**
+    * SnapshotLocation: project=**project-a** and volumeProject=**project-b**
+    * Bucket: **bucket-a**
+  * Create Velero restore **restore-b** from backup **backup-c**

--- a/velero-plugin-for-gcp/volume_snapshotter.go
+++ b/velero-plugin-for-gcp/volume_snapshotter.go
@@ -43,6 +43,7 @@ const (
 	zoneSeparator       = "__"
 	projectKey          = "project"
 	snapshotLocationKey = "snapshotLocation"
+	volumeProjectKey    = "volumeProject"
 )
 
 var pdCSIDriver = map[string]bool{
@@ -65,7 +66,8 @@ func newVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 }
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
-	if err := veleroplugin.ValidateVolumeSnapshotterConfigKeys(config, snapshotLocationKey, projectKey, credentialsFileConfigKey); err != nil {
+	if err := veleroplugin.ValidateVolumeSnapshotterConfigKeys(config,
+		snapshotLocationKey, projectKey, credentialsFileConfigKey, volumeProjectKey); err != nil {
 		return err
 	}
 
@@ -102,7 +104,10 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 
 	b.snapshotLocation = config[snapshotLocationKey]
 
-	b.volumeProject = creds.ProjectID
+	b.volumeProject = config[volumeProjectKey]
+	if b.volumeProject == "" {
+		b.volumeProject = creds.ProjectID
+	}
 
 	// get snapshot project from 'project' config key if specified,
 	// otherwise from the credentials file


### PR DESCRIPTION
#92 described a new scenario of cross-project backup and restore:
Velero is assigned with a service account and role in a separate GCP project, say the project name as `project-a`, then the Velero is used to backup and restore in other GCP projects, e.g. `project-b` and ` project-c`.

This PR is created to address this need, then also support the existing cross-project scenario described in the document https://github.com/vmware-tanzu/velero-plugin-for-gcp/blob/main/examples/gcp-projects.md.