### PR TITLE
release-1.8 Issue #6921: Unbreak compute engine url signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,6 @@ This involves creating an external credential file and using it as `--secret-fil
 
 #### Option 3: Using GKE Workload Identity
 
-Keep in mind that [Workforce Identity Federation Users cannot generate signed URLs](https://cloud.google.com/iam/docs/federated-identity-supported-services#:~:text=workforce%20identity%20federation%20users%20cannot%20generate%20signed%20URLs.). This means, if you are using Workforce Identity Federation, you will not be able to run `velero backup logs`, `velero backup download`, `velero backup describe` and `velero restore describe`.
-
 This requires a GKE cluster with workload identity enabled.
 
 1. Create Velero Namespace

--- a/changelogs/unreleased/159-kaovilai
+++ b/changelogs/unreleased/159-kaovilai
@@ -1,0 +1,1 @@
+Regression fix: Unbreak signed urls for compute engine

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -301,8 +301,10 @@ func (o *ObjectStore) SignBytes(bytes []byte) ([]byte, error) {
 }
 
 func (o *ObjectStore) CreateSignedURL(bucket, key string, ttl time.Duration) (string, error) {
-	if o.fileCredType != serviceAccountKey {
-		return "", errors.New("cannot sign blob using non SA file credentials")
+	// googleAccessID is initialized from ServiceAccount key file and compute engine credentials.
+	// If using external_account credentials, googleAccessID will be empty and we cannot create signed URL.
+	if o.googleAccessID == "" {
+		return "", errors.New("GoogleAccessID is empty, perhaps using external_account credentials, cannot create signed URL")
 	}
 	options := storage.SignedURLOptions{
 		GoogleAccessID: o.googleAccessID,


### PR DESCRIPTION
cherrypicks #158

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Remove doc assumptions that `GKE Workload Identity` = `Workload Identity Federation` and cannot generate signed URLs

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>
