### PR TITLE
update README GKE Workload Identity instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,16 @@ Namespace is already created in step 1 above.
     ```bash
     gcloud iam service-accounts add-iam-policy-binding \
         --role roles/iam.workloadIdentityUser \
-        --member "serviceAccount:[$PROJECT_ID].svc.id.goog[$NAMESPACE/$KSA_NAME]" \
-        [$GSA_NAME]@[$PROJECT_ID].iam.gserviceaccount.com
+        --member "serviceAccount:$PROJECT_ID.svc.id.goog[$NAMESPACE/$KSA_NAME]" \
+        $GSA_NAME@$PROJECT_ID.iam.gserviceaccount.com
+    ```
+
+4. Add annotation to Kubernetes Service Account
+
+    ```bash
+    kubectl annotate serviceaccount $KSA_NAME \
+        --namespace $NAMESPACE \
+        iam.gke.io/gcp-service-account=$GSA_NAME@$PROJECT_ID.iam.gserviceaccount.com
     ```
 
 In this case:

--- a/changelogs/unreleased/194-rvandernoort
+++ b/changelogs/unreleased/194-rvandernoort
@@ -1,0 +1,1 @@
+update README GKE Workload Identity instructions

--- a/changelogs/unreleased/195-rvandernoort
+++ b/changelogs/unreleased/195-rvandernoort
@@ -1,0 +1,1 @@
+update README GKE Workload Identity instructions

--- a/changelogs/unreleased/195-rvandernoort
+++ b/changelogs/unreleased/195-rvandernoort
@@ -1,1 +1,0 @@
-update README GKE Workload Identity instructions


### PR DESCRIPTION
This PR updates the docs of GKE Workload Identity by:
1. removing the `[]` brackets from the inappropriate spots according to [the google docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam)
2. Adding missing step of annotating the k8s serviceaccount to couple it with the gcp serviceaccount. 
