### PR TITLE
Prepare for v1.11.1-rc.1.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.22.8'
+        go-version: '1.22.10'
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.22.8'
+        go-version: '1.22.10'
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.22.8-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.22.10-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/changelogs/CHANGELOG-1.11.md
+++ b/changelogs/CHANGELOG-1.11.md
@@ -1,3 +1,13 @@
+# v1.11.1
+
+## All changes
+
+* Bump golang.org/x/crypto package version to v0.31.0 to fix CVEs. (#212, @blackpiglet)
+* Fix the issue pushing image to GCR. (#211, @reasonerjt)
+
+
+# v1.11.0
+
 ## All changes
 
 * Bump depending velero version to latest main commit. (#195, @blackpiglet)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
-	github.com/vmware-tanzu/velero v1.15.0
+	github.com/vmware-tanzu/velero v1.15.1-rc.1
 	golang.org/x/oauth2 v0.19.0
 	google.golang.org/api v0.172.0
 	k8s.io/api v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/vmware-tanzu/velero v1.15.0 h1:+S/lNSDwQqlROGWfmNuZnnabopGmco978COIt3AP09c=
-github.com/vmware-tanzu/velero v1.15.0/go.mod h1:28VhzPJRBo91GBRkgs4Ird0fx2vCpepBWmhF+5Pn/WQ=
+github.com/vmware-tanzu/velero v1.15.1-rc.1 h1:riVx9qbpbLYjXA6LwH7xJMIjsF53YKcEQLOA4RxMxRE=
+github.com/vmware-tanzu/velero v1.15.1-rc.1/go.mod h1:bZbnBC9OcwXfsovU0uCHwPlbm3ba8N9fwvBkwnU2vls=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Add change log.
Bump Golang version to v1.22.10.
Pin velero package version to v1.15.1-rc.1