### PR TITLE
feat: Add support for non-default google cloud universe domain

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -48,4 +48,9 @@ spec:
     #
     # Optional.
     storeEndpoint: storage-example.p.googleapis.com
+
+    # Configuration of the universe domain
+    #
+    # Optional.
+    universeDomain: googleapis.com
 ```

--- a/changelogs/unreleased/228-7sinStone.md
+++ b/changelogs/unreleased/228-7sinStone.md
@@ -1,0 +1,14 @@
+# Add universeDomain parameter for GCS client
+
+**Type:** Feature
+
+**Description:**
+Introduce a new `universeDomain` key in the BackupStorageLocation `spec.config` map,
+allowing users to override the default Google Storage domain (defaults to `"googleapis.com"`).
+
+**Motivation:**
+- Support custom or private GCS-compatible endpoints (e.g. testing, on‑prem).
+- Align with Helm chart support for `universeDomain`.
+
+**Changes:**
+- Updated `object_storage.go` to inject `option.WithUniverseDomain(...)`.

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -37,9 +37,10 @@ import (
 
 const (
 	kmsKeyNameConfigKey      = "kmsKeyName"
-	serviceAccountConfig     = "serviceAccount"
+	serviceAccountConfigKey     = "serviceAccount"
 	credentialsFileConfigKey = "credentialsFile"
 	storeEndpointConfigKey   = "storeEndpoint"
+	universeDomainKey   = "universeDomain"
 )
 
 // bucketWriter wraps the GCP SDK functions for accessing object store so they can be faked for testing.
@@ -100,9 +101,10 @@ func (o *ObjectStore) Init(config map[string]string) error {
 	if err := veleroplugin.ValidateObjectStoreConfigKeys(
 		config,
 		kmsKeyNameConfigKey,
-		serviceAccountConfig,
+		serviceAccountConfigKey,
 		credentialsFileConfigKey,
 		storeEndpointConfigKey,
+		universeDomainKey,
 	); err != nil {
 		return err
 	}
@@ -144,6 +146,11 @@ func (o *ObjectStore) Init(config map[string]string) error {
 	// if using a endpoint, we need to pass it when creating the object store client
 	if endpoint, ok := config[storeEndpointConfigKey]; ok {
 		clientOptions = append(clientOptions, option.WithEndpoint(endpoint))
+	}
+
+	// if using a universeDomain, we need to pass it when creating the object store client
+	if universeDomain, ok := config[universeDomainKey]; ok {
+		clientOptions = append(clientOptions, option.WithUniverseDomain(universeDomain))
 	}
 
 	if creds.JSON != nil {


### PR DESCRIPTION
This introduces a new `universeDomain` key in the BackupStorageLocation `spec.config` map, allowing users to override the default Google Storage domain. When not provided, it defaults to "googleapis.com". 
This is useful for targeting custom or private GCS‑compatible endpoints (e.g., staging, on‑prem, regional tests).

Fixes https://github.com/vmware-tanzu/velero/issues/8900

Signed-off-by: Houssein Mnaouar <houssein.mnaouar@gmail.com>