### PR TITLE
v1.13: Fix ObjectExists method to properly handle wrapped storage.ErrObjectNotExist errors from Google Cloud Storage API

### DIFF
--- a/changelogs/unreleased/240-kaovilai
+++ b/changelogs/unreleased/240-kaovilai
@@ -1,0 +1,1 @@
+v1.13: Fix ObjectExists method to properly handle wrapped storage.ErrObjectNotExist errors from Google Cloud Storage API

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -37,10 +37,10 @@ import (
 
 const (
 	kmsKeyNameConfigKey      = "kmsKeyName"
-	serviceAccountConfigKey     = "serviceAccount"
+	serviceAccountConfigKey  = "serviceAccount"
 	credentialsFileConfigKey = "credentialsFile"
 	storeEndpointConfigKey   = "storeEndpoint"
-	universeDomainKey   = "universeDomain"
+	universeDomainKey        = "universeDomain"
 )
 
 // bucketWriter wraps the GCP SDK functions for accessing object store so they can be faked for testing.
@@ -233,7 +233,7 @@ func (o *ObjectStore) PutObject(bucket, key string, body io.Reader) error {
 
 func (o *ObjectStore) ObjectExists(bucket, key string) (bool, error) {
 	if _, err := o.bucketWriter.getAttrs(bucket, key); err != nil {
-		if err == storage.ErrObjectNotExist {
+		if errors.Is(err, storage.ErrObjectNotExist) {
 			return false, nil
 		}
 		return false, errors.WithStack(err)

--- a/velero-plugin-for-gcp/object_store_test.go
+++ b/velero-plugin-for-gcp/object_store_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	velerotest "github.com/vmware-tanzu/velero/pkg/test"
@@ -120,6 +121,11 @@ func TestObjectExists(t *testing.T) {
 		{
 			name:           "doesn't exist",
 			errorResponse:  storage.ErrObjectNotExist,
+			expectedExists: false,
+		},
+		{
+			name:           "doesn't exist - wrapped error",
+			errorResponse:  pkgerrors.Wrap(storage.ErrObjectNotExist, "googleapi: Error 404: No such object"),
 			expectedExists: false,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Prasad Joshi <prajoshi@redhat.com>

Fixes https://github.com/vmware-tanzu/velero/issues/9268

cherrypick #239 