### PR TITLE
enable the BSL service account to be used for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Note that Google Service Account keys are valid for decades (no clear expiry dat
 
 #### Option 2: Using File-sourced workforce identity federation short lived credentials
 
-Keep in mind that [Workforce Identity Federation Users cannot generate signed URLs](https://cloud.google.com/iam/docs/federated-identity-supported-services#:~:text=workforce%20identity%20federation%20users%20cannot%20generate%20signed%20URLs.). This means, if you are using Workforce Identity Federation, you will not be able to run `velero backup logs`, `velero backup download`, `velero backup describe` and `velero restore describe`.
+Keep in mind that [Workforce Identity Federation Users cannot generate signed URLs](https://cloud.google.com/iam/docs/federated-identity-supported-services#:~:text=workforce%20identity%20federation%20users%20cannot%20generate%20signed%20URLs.) directly as the federated identity. However, you can still generate signed URLs by setting `serviceAccount` in the BackupStorageLocation config so that the plugin impersonates that service account (using the `iam.serviceAccounts.signBlob` permission) instead of signing directly. This enables `velero backup logs`, `velero backup download`, `velero backup describe` and `velero restore describe` when using Workforce/Workload Identity Federation.
 
 This involves creating an external credential file and using it as `--secret-file` during [installation](#Install-and-start-Velero).
 

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -35,6 +35,8 @@ spec:
 
     # Name of the GCP service account to use for this backup storage location. Specify the
     # service account here if you want to use workload identity instead of providing the key file.
+    # It is also required when using Workforce/Workload Identity Federation (external_account
+    # credentials) so that the plugin can impersonate this service account to generate signed URLs.
     #
     # Optional (defaults to "false").
     serviceAccount: my-service-account

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -158,9 +158,13 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		if o.fileCredType == serviceAccountKey {
+		switch o.fileCredType {
+		case serviceAccountKey:
 			// Using Credentials File
 			err = o.initFromKeyFile(creds)
+		case externalAccountKey:
+			// Using Workload Identity Federation - read serviceAccount from BSL config for signing
+			err = o.initFromComputeEngine(config)
 		}
 	} else {
 		// Using compute engine credentials. Use this if workload identity is enabled.

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -165,6 +165,8 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		case externalAccountKey:
 			// Using Workload Identity Federation - read serviceAccount from BSL config for signing
 			err = o.initFromComputeEngine(config)
+		default:
+			o.log.Warnf("Unknown credentials type %q, skipping credentials initialization", o.fileCredType)
 		}
 	} else {
 		// Using compute engine credentials. Use this if workload identity is enabled.

--- a/velero-plugin-for-gcp/object_store_test.go
+++ b/velero-plugin-for-gcp/object_store_test.go
@@ -158,6 +158,13 @@ func TestObjectExists(t *testing.T) {
 	}
 }
 
+func TestCreateSignedURL_emptyGoogleAccessID(t *testing.T) {
+	o := newObjectStore(velerotest.NewLogger())
+	// googleAccessID is empty — simulates external_account credentials with no serviceAccount in BSL config
+	_, err := o.CreateSignedURL("bucket", "key", 0)
+	require.EqualError(t, err, "GoogleAccessID is empty, perhaps using external_account credentials, cannot create signed URL")
+}
+
 func Test_getSecretAccountKey(t *testing.T) {
 	type args struct {
 		secretByte []byte

--- a/velero-plugin-for-gcp/object_store_test.go
+++ b/velero-plugin-for-gcp/object_store_test.go
@@ -165,6 +165,13 @@ func TestCreateSignedURL_emptyGoogleAccessID(t *testing.T) {
 	require.EqualError(t, err, "GoogleAccessID is empty, perhaps using external_account credentials, cannot create signed URL")
 }
 
+func TestInitFromComputeEngine_missingServiceAccount(t *testing.T) {
+	o := newObjectStore(velerotest.NewLogger())
+	// external_account credentials require a serviceAccount in the BSL config for signing
+	err := o.initFromComputeEngine(map[string]string{})
+	require.EqualError(t, err, "serviceAccount is expected to be provided as an item in BackupStorageLocation's config")
+}
+
 func Test_getSecretAccountKey(t *testing.T) {
 	type args struct {
 		secretByte []byte


### PR DESCRIPTION
When `GOOGLE_APPLICATION_CREDENTIALS` points to a `federation.json` (external_account credentials), the `Init()` method detected the credential type but had no handling for it — falling through without setting `googleAccessID`. The `initFromComputeEngine` path (which reads `serviceAccount` from BSL config) was only reachable when no credentials file was present.

This adds `external_account` as an explicit case in the credential type switch, calling `initFromComputeEngine` to read `serviceAccount` from BSL config and set up IAM-based signing. This unblocks `DownloadRequest` operations (e.g. `velero describe --details`) for clusters using the federation webhook.