### PR TITLE
enable the BSL service account to be used for requests

### DIFF
--- a/.github/workflows/test-local-publish.yml
+++ b/.github/workflows/test-local-publish.yml
@@ -1,0 +1,43 @@
+name: Test Local Publish
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - 'release-**'
+
+jobs:
+  build-and-push:
+    name: Build and Push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        run: |
+          VERSION="${{ github.ref_name }}" \
+          REGISTRY="ghcr.io/s3than" \
+          BUILDX_PLATFORMS="linux/amd64,linux/arm64" \
+          BUILDX_OUTPUT_TYPE="registry" \
+          make container

--- a/velero-plugin-for-gcp/object_store.go
+++ b/velero-plugin-for-gcp/object_store.go
@@ -158,9 +158,13 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		if o.fileCredType == serviceAccountKey {
+		switch o.fileCredType {
+		case serviceAccountKey:
 			// Using Credentials File
 			err = o.initFromKeyFile(creds)
+		case externalAccountKey:
+			// Using Workload Identity Federation - read serviceAccount from BSL config for signing
+			err = o.initFromComputeEngine(config)
 		}
 	} else {
 		// Using compute engine credentials. Use this if workload identity is enabled.

--- a/velero-plugin-for-gcp/object_store_test.go
+++ b/velero-plugin-for-gcp/object_store_test.go
@@ -158,6 +158,13 @@ func TestObjectExists(t *testing.T) {
 	}
 }
 
+func TestCreateSignedURL_emptyGoogleAccessID(t *testing.T) {
+	o := newObjectStore(velerotest.NewLogger())
+	// googleAccessID is empty — simulates external_account credentials with no serviceAccount in BSL config
+	_, err := o.CreateSignedURL("bucket", "key", 0)
+	require.EqualError(t, err, "GoogleAccessID is empty, perhaps using external_account credentials, cannot create signed URL")
+}
+
 func Test_getSecretAccountKey(t *testing.T) {
 	type args struct {
 		secretByte []byte


### PR DESCRIPTION
Test release of the plugin change

Signed-off-by: Tim Colbert <s3than@users.noreply.github.com>