### PR TITLE
Update for 1.14.1-rc.2

### DIFF
--- a/.github/workflows/get-go-version.yaml
+++ b/.github/workflows/get-go-version.yaml
@@ -25,7 +25,7 @@ jobs:
               version=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1-2)
             else
               goDirectiveVersion=$(grep '^go ' go.mod | awk '{print $2}')
-              toolChainVersion=$(grep '^toolchain ' go.mod | awk '{print $2}')
+              toolChainVersion=$(grep '^toolchain ' go.mod | awk '{print $2}' | sed 's/^go//')
               version=$(printf "%s\n%s\n" "$goDirectiveVersion" "$toolChainVersion" | sort -V | tail -n1)
             fi
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,7 +56,7 @@ jobs:
 
     # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
     - name: Publish container image
-      if: github.repository == 'vmware-tanzu/velero-plugin-for-gcp'
+      if: github.repository == 'velero-io/velero-plugin-for-gcp'
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
         ./hack/docker-push.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.25.9-trixie AS build
+FROM --platform=$BUILDPLATFORM golang:1.25.10-trixie AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/vmware-tanzu/velero-plugin-for-gcp
 
-go 1.25.9
+go 1.25.7
+
+toolchain go1.25.10
 
 require (
 	cloud.google.com/go/storage v1.57.2
@@ -9,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.11.1
-	github.com/vmware-tanzu/velero v1.18.1-rc.1
+	github.com/vmware-tanzu/velero v1.18.0
 	golang.org/x/oauth2 v0.34.0
 	google.golang.org/api v0.256.0
 	k8s.io/api v0.33.3

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vmware-tanzu/velero v1.18.1-rc.1 h1:7EM2eMffGiPzz7p1OJjSfUxQxTFnC5KfGws0C9ZEcCY=
-github.com/vmware-tanzu/velero v1.18.1-rc.1/go.mod h1:6yTectlAl2auBgNwJMF6RVL1brWGIMhnMJdiCfBGxtM=
+github.com/vmware-tanzu/velero v1.18.0 h1:szADU7zjNF5vhWM3tX/ttzkODclhShOfu8G12/fnmFE=
+github.com/vmware-tanzu/velero v1.18.0/go.mod h1:MrbDXkA39TFvLzpznrhdWs0QFcbFbQauTHqYLcrzSj4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
* Bump golang to 1.25.10
* Change velero dependency to v1.18.0
* Modify get-go-version action
* Modify the repository address in push action