### PR TITLE
[release-1.13] Bump golang to 1.25 to fix CVEs. (cherry-pick #245)

### DIFF
--- a/.github/workflows/get-go-version.yaml
+++ b/.github/workflows/get-go-version.yaml
@@ -1,0 +1,33 @@
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The target branch's ref"
+        required: true
+        type: string
+    outputs:
+      version: 
+        description: "The expected Go version"
+        value: ${{ jobs.extract.outputs.version }}
+
+jobs:
+  extract:
+      runs-on: ubuntu-latest
+      outputs:
+        version: ${{ steps.pick-version.outputs.version }}
+      steps:
+        - name: Check out the code
+          uses: actions/checkout@v6
+
+        - id: pick-version
+          run: |
+            if [ "${{ inputs.ref }}" == "main" ]; then
+              version=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1-2)
+            else
+              goDirectiveVersion=$(grep '^go ' go.mod | awk '{print $2}')
+              toolChainVersion=$(grep '^toolchain ' go.mod | awk '{print $2}')
+              version=$(printf "%s\n%s\n" "$goDirectiveVersion" "$toolChainVersion" | sort -V | tail -n1)
+            fi
+
+            echo "version=$version"
+            echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,10 +1,15 @@
 name: Run CI
 on: [pull_request]
 jobs:
+  get-go-version:
+    uses: ./.github/workflows/get-go-version.yaml
+    with:
+      ref: ${{ github.event.pull_request.base.ref }}
 
   build:
     name: Run CI
     runs-on: ubuntu-latest
+    needs: get-go-version
     steps:
 
     - name: Check out the code
@@ -13,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version: ${{ needs.get-go-version.outputs.version }}
       id: go
 
     - name: Make CI

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,10 +9,15 @@ on:
       - '*'
 
 jobs:
+  get-go-version:
+    uses: ./.github/workflows/get-go-version.yaml
+    with:
+      ref: ${{ github.ref_name }}
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: get-go-version
     steps:
 
     - name: Check out code into the Go module directory
@@ -21,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: ${{ needs.get-go-version.outputs.version }}
       id: go
 
     - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.24.11-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/vmware-tanzu/velero-plugin-for-gcp
 
-go 1.24.0
-
-toolchain go1.24.11
+go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.55.0


### PR DESCRIPTION
Cherry-pick of #245 to `release-1.13`.

Original PR: https://github.com/velero-io/velero-plugin-for-gcp/pull/245

Conflicts (Dockerfile golang base image version, go.mod golang.org/x/exp entry) resolved manually; `go mod tidy` re-run to reconcile go.sum. Resulting go.mod matches upstream main's #245 exactly (`go 1.25.0`, no toolchain directive).